### PR TITLE
Fix printf import

### DIFF
--- a/src/tshr.rs
+++ b/src/tshr.rs
@@ -175,7 +175,7 @@ pub fn snprintf(
 #[cfg_attr(not(test), no_mangle)]
 pub fn main(
 	argc: i32,
-	argv: *const *const u8,
+	argv: *const *const c_char,
 	envp: *const *const u8,
 ) -> i8 {
 	// Check that we have the args
@@ -186,16 +186,10 @@ pub fn main(
 	// Parse argv
 	let argv_ptrs =
 		unsafe { std::slice::from_raw_parts(argv, argc as usize) };
-	let ip_str = unsafe {
-		CStr::from_ptr(argv_ptrs[1] as *const c_char)
-			.to_str()
-			.unwrap()
-	};
-	let key_str = unsafe {
-		CStr::from_ptr(argv_ptrs[2] as *const c_char)
-			.to_str()
-			.unwrap()
-	};
+	let ip_str =
+		unsafe { CStr::from_ptr(argv_ptrs[1]).to_str().unwrap() };
+	let key_str =
+		unsafe { CStr::from_ptr(argv_ptrs[2]).to_str().unwrap() };
 	// Parse the IP
 	let ipaddr_l: Ipv4Addr =
 		ip_str.parse().expect("Failed to parse IP");


### PR DESCRIPTION
Define our own `snprintf` in true hacker fashion.