### PR TITLE
Alternate solution: rewrite ptsname to not use printf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,12 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,7 +910,6 @@ dependencies = [
  "anyhow",
  "base64ct",
  "clap",
- "itoa",
  "lazy_static",
  "libc",
  "os_pipe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ clap = { version = "*", features = ["derive"] }
 os_pipe = "*"
 base64ct = "*"
 termion = "*"
-itoa = "*"
 
 [dev-dependencies]
 rand = { version = "*", features = ["small_rng"] }


### PR DESCRIPTION
Same problem different solution (as compared to #16) - instead of writing our own `snprintf`, we write our `ptsname_r` function (since that was the function that used `snprintf`).

The size results are actually exactly the same, so it comes down to which solution we think is more elegant and readable.